### PR TITLE
new_post.sh: explicitly use bash

### DIFF
--- a/new_post.sh
+++ b/new_post.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 date_pattern=`date "+%Y-%m-%d"`-
 


### PR DESCRIPTION
If we use dash as /bin/sh then we have a problem
with 'read' buildin command. Here is the log:

 $ ls -la /bin/sh
 lrwxrwxrwx 1 root root 4 Dec 24  2012 /bin/sh -> dash
 $ ./new_post.sh
 Post name > ./new_post.sh: 5: read: arg count
 ./new_post.sh: 24: ./new_post.sh: posts/.2013-12-15-.md: Permission denied

Signed-off-by: Antony Pavlov antonynpavlov@gmail.com
